### PR TITLE
Update seed.sql include tblproperties

### DIFF
--- a/dbt/include/spark/macros/materializations/seed.sql
+++ b/dbt/include/spark/macros/materializations/seed.sql
@@ -69,6 +69,7 @@
     {{ clustered_cols(label="clustered by") }}
     {{ location_clause() }}
     {{ comment_clause() }}
+    {{ tblproperties_clause() }}
   {% endset %}
 
   {% call statement('_') -%}


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#



### Problem

Currently the tblproperties macro is declared but it's not used in the create table statement 

### Solution

include tblproperties_clause() macro in seed.sql

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
